### PR TITLE
Fix tag workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
           docker_layer_caching: true
       - checkout
       - run:
-          name: bake
-          command: make bake
+          name: prepare Dockerfiles
+          command: make prepare
       - run:
           name: build
           command: make build
@@ -44,7 +44,7 @@ jobs:
           paths:
             - var
 
-  promote:
+  tag:
     <<: *defaults
     steps:
       - attach_workspace:
@@ -53,11 +53,13 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Merge from develop
+          name: prepare git
           command: |
-            merge-develop.sh
+            git config user.email "circleci-bot@greenpeace.org"
+            git config user.name "CircleCI Bot"
+            git config merge.ours.driver true
       - run:
-          name: Tag
+          name: tag
           command: |
             current_version=$(git-current-tag.sh)
             new_version=$(increment-version.sh $current_version)
@@ -71,23 +73,20 @@ workflows:
     jobs:
       - build-push:
           context: org-global
-          filters:
-            branches:
-              ignore: master
-      - hold-promote:
+      - hold-tag:
           type: approval
           requires:
             - build-push
           filters:
             branches:
-              only: develop
-      - promote:
+              only: main
+      - tag:
           context: org-global
           requires:
-            - hold-promote
+            - hold-tag
           filters:
             branches:
-              only: develop
+              only: main
 
   tag:
     jobs:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+  line-length:
+    max: 99

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ YAMLLINT := $(shell command -v yamllint 2> /dev/null)
 
 # ============================================================================
 
-all: init bake build test push
+all: init prepare build test push
 
 init:
 	@chmod 755 .githooks/*
@@ -75,7 +75,7 @@ endif
 	done
 	docker run --rm -i hadolint/hadolint < node/Dockerfile
 
-bake: Dockerfile
+prepare: Dockerfile
 
 Dockerfile:
 	for v in $(PHP_VERSIONS); do \

--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ Includes dependencies needed for phpunit testing suite and lint checks for css/j
 
 ## Development
 
-Run `make init` after cloning to ensure you have the pre-commit hooks installed.
+Running `make` will build the images and run the tests.
 
 ### Requirements
 
 1.  Docker
 2.  yamllint
-3.  circleci
+
+#### Tests requirements
+
+1. ag
+2. bats


### PR DESCRIPTION
Our current merge scripts used elsewhere are not very generic, so they fail. Adding the commands in the CI for now. Hopefully we will touch this again once we refactor our main scripts 🤞🏻 

It's a good opportunity also to simplify the branching scheme of these repos, and let this be the first one who also uses `main` instead of `master`.