### PR TITLE
Add pa11y and bump composer version

### DIFF
--- a/Dockerfile.node.in
+++ b/Dockerfile.node.in
@@ -4,6 +4,17 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
 
-RUN npm install -g stylelint@${STYLELINT_VERSION} eslint@${ESLINT_VERSION}
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 \
+    libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 \
+    libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
+    libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils \
+    libxshmfence1 libglu1 && \
+    npm install -g stylelint@${STYLELINT_VERSION} eslint@${ESLINT_VERSION} \
+    pa11y-ci@${PA11Y_CI_VERSION} pa11y-ci-reporter-html@${PA11Y_CI_REPORTER_HTML_VERSION} && \
+    rm -rf /tmp/* && \
+    rm -rf /var/lib/apt/lists/*
 
 USER circleci

--- a/Dockerfile.php.in
+++ b/Dockerfile.php.in
@@ -4,16 +4,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 USER root
 
-# Install Composer 1.10.19
-# https://github.com/greenpeace/planet4-docker/blob/master/config.default#L42
-RUN composer self-update --1
-
-# RUN echo 'deb http://ftp.us.debian.org/debian sid main' | tee -a /etc/apt/sources.list
-# hadolint ignore=DL3009
-RUN apt-get update
 # hadolint ignore=DL3008
-RUN apt-get install --no-install-recommends -y build-essential mariadb-client subversion php-xdebug \
- && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y build-essential mariadb-client subversion php-xdebug && \
+  rm -rf /var/lib/apt/lists/*
 
 USER circleci
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ Dockerfile:
 			< $$f > php/$${v}/$@ ; \
 	done
 	mkdir -p node
-	envsubst '$${NODE_IMAGE_NAME},$${NODE_VERSION},$${STYLELINT_VERSION},$${ESLINT_VERSION}' \
+	envsubst '$${NODE_IMAGE_NAME},$${NODE_VERSION},$${STYLELINT_VERSION},$${ESLINT_VERSION} \
+		$${PA11Y_CI_VERSION},$${PA11Y_CI_REPORTER_HTML_VERSION}' \
 		< Dockerfile.node.in > node/Dockerfile
 
 build:

--- a/config.default
+++ b/config.default
@@ -1,5 +1,5 @@
 PHP_IMAGE_NAME=cimg/php
-PHP_VERSIONS=7.3 7.4 8.0
+PHP_VERSIONS=7.4 8.0
 
 NODE_IMAGE_NAME=cimg/node
 NODE_VERSION=lts
@@ -9,3 +9,9 @@ STYLELINT_VERSION=13.8.0
 
 # https://www.npmjs.com/package/eslint
 ESLINT_VERSION=7.15.0
+
+# https://www.npmjs.com/package/pa11y-ci
+PA11Y_CI_VERSION=3.0.1
+
+# https://www.npmjs.com/package/pa11y-ci-reporter-html
+PA11Y_CI_REPORTER_HTML_VERSION=5.0.2


### PR DESCRIPTION
- Use composer 2, to match the rest of our setup
- Install pa11y-ci, its html reporter and all system dependencies needed by puppeteer.

The last one will enable to run a11y tests on test instances ([ref](https://jira.greenpeace.org/browse/PLANET-5872)).

---

This is an [example pipeline](https://app.circleci.com/pipelines/github/greenpeace/planet4-master-theme/6376/workflows/47eeaf9c-7c3f-45ea-8766-2f8ed4995d78) using both php (in the `php74-tests` job) and node (in `frontend-tests` and `a11y-tests` jobs) container images.